### PR TITLE
Singular ping

### DIFF
--- a/lib/sean/connery.rb
+++ b/lib/sean/connery.rb
@@ -1,4 +1,5 @@
 require "sean/connery/version"
+require 'pry'
 
 module Sean
   module Connery
@@ -9,6 +10,13 @@ module Sean
         owner = base.method(method).owner
         owner.send :alias_method, method.to_s.gsub('s','sh').to_sym, method
       end
+    end
+
+    def ping
+      result = super
+      undef ping
+      puts 'One. ping. only.'
+      result
     end
 
     module ClassMethods

--- a/sean-connery.gemspec
+++ b/sean-connery.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry"
 end

--- a/spec/sean/connery_spec.rb
+++ b/spec/sean/connery_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 class Stub
   include Sean::Connery
@@ -11,10 +12,26 @@ class Stub
   end
 end
 
+
 describe Sean::Connery do
   subject { Stub.new }
 
   it 'has seanified class methods' do
     expect(subject.methods).to be []
+  end
+
+  it 'can only ping once' do
+    class Ping
+      prepend Sean::Connery
+
+      def ping
+        'Verify our range to target'
+      end
+    end
+
+    p = Ping.new
+
+    expect(p.ping).to eq 'Verify our range to target'
+    expect { p.ping }.to raise_error(NoMethodError)
   end
 end


### PR DESCRIPTION
https://www.youtube.com/watch?v=jr0JaXfKj68

Ruby doesn't have a standard `ping` method anymore but a lot of libraries do.
There should be "one ping only" allowed.
